### PR TITLE
11992 fully answered questions

### DIFF
--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -17,7 +17,7 @@
 </div>
 <div class="modal-body">
   <p id="not-answered-questions" *ngIf="notYetAnsweredQuestions.length !== 0">
-    <i class="fas fa-exclamation"></i> Note that some questions are yet to be fully answered.
+    <i class="fas fa-exclamation"></i> Note that you may still add responses to some questions.
     They are: {{ notYetAnsweredQuestions.join(', ') }}.
   </p>
   <div *ngIf="hasFailToSaveQuestions" class="text-danger" style="margin-bottom: 10px;">

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -703,6 +703,13 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                     questionSubmissionFormModel.questionType, recipientSubmissionFormModel.responseDetails);
             isQuestionFullyAnswered = isQuestionFullyAnswered && !isFeedbackResponseDetailsEmpty;
 
+            //TODO Redefine what we mean by "fully answered questions". Questions with empty feedback response details
+            // may be considered fully answered if it has a minimum number of responses. May require implementing a
+            // minNumberOfResponses attribute to the questions.
+
+            // isQuestionFullyAnswered = isQuestionFullyAnswered && (!isFeedbackResponseDetailsEmpty
+            //     || !hasMinNumberOfResponses)
+
             if (!isFeedbackResponseDetailsEmpty) {
               responses.push({
                 recipient: recipientSubmissionFormModel.recipientIdentifier,


### PR DESCRIPTION
An attempt to fix issue 11992.

Some questions do not require users to input their responses for every single student (eg. allowing students to provide feedback for up to 10 students in the course). Yet, when the feedback is being saved, the question will be highlighted as "not fully answered" even though the feedback has been saved successfully. This may raise some concerns among the user.

Example of the saving complete modal:
![image](https://user-images.githubusercontent.com/57744421/208240232-880c2a4e-0af1-456b-be70-8d10fb6e1d3f.png)

Trivial solution: To prevent confusion, we can re-word the warning such that it does not expect users to fill in every single response to a question.
![image](https://user-images.githubusercontent.com/57744421/208240358-b230ad33-be59-4b46-8fd0-da71b963e472.png)

Currently, the only factor determining if a question is fully answered is whether the feedback response details are empty (isFeedbackResponseDetailsEmpty in feedback-responses.services.ts). Moving ahead, there may be a need for the logic of a fully answered question to be changed. This may require adding a minNumberOfResponsesRequired attribute to questions and including an additional method in FeedbackResponsesServices that does the checking of the number of non-empty responses with the minNumberOfResponsesRequired.